### PR TITLE
🧹 Restore debug assertion for cyclic transformations in Trans::insert

### DIFF
--- a/crates/rule-engine/src/transform/trans.rs
+++ b/crates/rule-engine/src/transform/trans.rs
@@ -250,8 +250,7 @@ impl Trans<String> {
 impl Trans<MetaVariable> {
     pub(super) fn insert<D: Doc>(&self, key: &str, ctx: &mut Ctx<'_, '_, D>) {
         let src = self.source();
-        // TODO: add this debug assertion back
-        // debug_assert!(ctx.env.get_transformed(key).is_none());
+        debug_assert!(ctx.env.get_transformed(key).is_none());
         // avoid cyclic
         ctx.env.insert_transformation(src, key, vec![]);
         let opt = self.compute(ctx);


### PR DESCRIPTION
🎯 **What:** Restored a commented-out debug assertion (`debug_assert!(ctx.env.get_transformed(key).is_none());`) in `crates/rule-engine/src/transform/trans.rs`.
💡 **Why:** This improves maintainability and helps catch cyclic transformation issues early during development in debug builds. The code had a TODO to add this back, so it was clearly an intended check.
✅ **Verification:** Ran `cargo test -p thread-rule-engine` to confirm that restoring the assertion did not break any existing functionality. All tests passed.
✨ **Result:** Enhanced the robustness of transformation inserts by actively asserting against cyclic behavior when compiled in debug mode.

---
*PR created automatically by Jules for task [14795716212823335834](https://jules.google.com/task/14795716212823335834) started by @bashandbone*

## Summary by Sourcery

Bug Fixes:
- Re-enable a debug assertion to guard against inserting transformations when a transformed value already exists, helping catch cyclic transformation issues early in development.