### PR TITLE
🧹 [code health] Update Bash replace test to use metavariable

### DIFF
--- a/crates/language/src/bash.rs
+++ b/crates/language/src/bash.rs
@@ -39,7 +39,6 @@ fn test_bash_pattern_no_match() {
 
 #[test]
 fn test_bash_replace() {
-    // TODO: change the replacer to log $A
-    let ret = test_replace("echo 123", "echo $A", "log 123");
+    let ret = test_replace("echo 123", "echo $A", "log $A");
     assert_eq!(ret, "log 123");
 }


### PR DESCRIPTION
### 🎯 What:
The code health issue addressed is an actionable `TODO` in `crates/language/src/bash.rs` that suggested using a metavariable in the replacement string of `test_bash_replace`.

### 💡 Why:
This improves the test by verifying that the pattern matching engine correctly captures the value into the metavariable and substitutes it back into the replacement string, rather than relying on a hardcoded value. This makes the test a better validator of the underlying replacement logic.

### ✅ Verification:
The change was verified manually by checking the logic:
- Input: `"echo 123"`
- Pattern: `"echo $A"` (captures `$A = 123`)
- Replacer: `"log $A"`
- Expected Result: `"log 123"`
- Assertion: `assert_eq!(ret, "log 123")`

Automated tests were attempted but could not be completed due to environment-specific dependency issues (offline mode missing `mimalloc` and `bit-set` from the local Cargo cache). However, the logic is straightforward and consistent with other tests in the repository (e.g., in `rust.rs`).

### ✨ Result:
The `TODO` is resolved, the comment is removed, and the test is now more representative of real-world use cases for the pattern matching engine.

---
*PR created automatically by Jules for task [11195642146221711901](https://jules.google.com/task/11195642146221711901) started by @bashandbone*

## Summary by Sourcery

Update the Bash replacement test to validate metavariable substitution rather than a hardcoded replacement string.

Tests:
- Adjust the Bash replace test to use the captured metavariable in the replacer while asserting the substituted value.

Chores:
- Remove the resolved TODO comment related to improving the Bash replace test.