### PR TITLE
🔒 Fix command injection vulnerability in get-langs.sh eval

### DIFF
--- a/scripts/get-langs.sh
+++ b/scripts/get-langs.sh
@@ -144,6 +144,7 @@ run_cmd() {
     local url="$2"
     local action="$3"
     local branch="$4"
+    local label="${5:-language}"
     local word
     if [[ "$action" == "pull" ]]; then
         word="updating"
@@ -152,10 +153,10 @@ run_cmd() {
     else
         error_exit "Invalid action: $action. Use 'pull' or 'add'."
     fi
-    echo "[$word] $lang from $url branch: $branch"
+    echo "[$word] $label: $lang from $url branch: $branch"
     echo "executing command: git subtree --squash $PREFIX/$lang $action $url $branch"
-    git subtree --squash "$PREFIX/$lang" "$action" "$url" "$branch" 2>/dev/null || {
-        error_exit "Failed to process language: $lang"
+    git subtree --squash "$PREFIX/$lang" "$action" "$url" "$branch" || {
+        error_exit "Failed to process $label: $lang"
     }
 }
 
@@ -190,7 +191,7 @@ main() {
             continue
         fi
         repo_url=$(get_repo "$lang")
-        branch=${BRANCH[$lang]:-main}
+        branch=${BRANCH[lang]:-main}
         run_cmd "$lang" "$repo_url" "$ARG" "$branch"
     done
     for grammar in "${GRAMMAR_REPOS[@]}"; do
@@ -200,7 +201,7 @@ main() {
             continue
         fi
         repo_url=$(get_grammar_repo "$lang")
-        run_cmd "$lang" "$repo_url" "$ARG" "$branch"
+        run_cmd "$lang" "$repo_url" "$ARG" "$branch" "grammar"
     done
 }
 

--- a/scripts/get-langs.sh
+++ b/scripts/get-langs.sh
@@ -190,7 +190,7 @@ main() {
             continue
         fi
         repo_url=$(get_repo "$lang")
-        branch=${BRANCH[lang]:-main}
+        branch=${BRANCH[$lang]:-main}
         run_cmd "$lang" "$repo_url" "$ARG" "$branch"
     done
     for grammar in "${GRAMMAR_REPOS[@]}"; do

--- a/scripts/get-langs.sh
+++ b/scripts/get-langs.sh
@@ -139,7 +139,7 @@ get_grammar_repo() {
     }
 }
 
-get_cmd() {
+run_cmd() {
     local lang="$1"
     local url="$2"
     local action="$3"
@@ -153,8 +153,9 @@ get_cmd() {
         error_exit "Invalid action: $action. Use 'pull' or 'add'."
     fi
     echo "[$word] $lang from $url branch: $branch"
-    echo "git subtree --squash $PREFIX/$lang $action $url $branch" 2>/dev/null || {
-        error_exit "Failed to construct command for language: $lang"
+    echo "executing command: git subtree --squash $PREFIX/$lang $action $url $branch"
+    git subtree --squash "$PREFIX/$lang" "$action" "$url" "$branch" 2>/dev/null || {
+        error_exit "Failed to process language: $lang"
     }
 }
 
@@ -174,31 +175,23 @@ main() {
     echo "Running command: $ARG"
 
     for lang in "${LANGS[@]}"; do
-        local repo_url cmd
+        local repo_url
         if ! is_match "$lang"; then
             echo "Skipping language: $lang"
             continue
         fi
         repo_url=$(get_main_repo "$lang")
-        cmd=$(get_cmd "$lang" "$repo_url" "$ARG" "master")
-        echo "executing command: $cmd"
-        eval "$cmd" || {
-            error_exit "Failed to process language: $lang"
-        }
+        run_cmd "$lang" "$repo_url" "$ARG" "master"
     done
     for lang in "${REPO_LANGS[@]}"; do
-        local repo_url branch cmd
+        local repo_url branch
         if ! is_match "$lang"; then
             echo "Skipping language: $lang"
             continue
         fi
         repo_url=$(get_repo "$lang")
         branch=${BRANCH[lang]:-main}
-        cmd=$(get_cmd "$lang" "$repo_url" "$ARG" "$branch")
-        echo "executing command: $cmd"
-        eval "$cmd" || {
-            error_exit "Failed to process language: $lang"
-        }
+        run_cmd "$lang" "$repo_url" "$ARG" "$branch"
     done
     for grammar in "${GRAMMAR_REPOS[@]}"; do
         IFS=',' read -r lang branch <<<"$grammar"
@@ -207,11 +200,7 @@ main() {
             continue
         fi
         repo_url=$(get_grammar_repo "$lang")
-        cmd="$(get_cmd "$lang" "$repo_url" "$ARG" "$branch")"
-        echo "executing command: $cmd"
-        eval "$cmd" || {
-            error_exit "Failed to process grammar: $grammar"
-        }
+        run_cmd "$lang" "$repo_url" "$ARG" "$branch"
     done
 }
 


### PR DESCRIPTION
🎯 **What:**
Fixed a command injection vulnerability in `scripts/get-langs.sh`. The script was using `eval` to execute a multi-line string that contained unsanitized user inputs, such as arguments passed to the script or repository variables.

⚠️ **Risk:**
If untrusted input or manipulated environment variables were passed to the script's action or arguments, it could allow an attacker to execute arbitrary shell commands via the `eval` statement, compromising the build or developer environment.

🛡️ **Solution:**
Replaced the string-building `get_cmd` function with a `run_cmd` function that directly executes the `git subtree` command. By using standard bash argument arrays/quoting, the command is executed safely without the risk of shell metacharacter injection. The execution reporting (`echo`) is also clearly separated from the actual command execution.

---
*PR created automatically by Jules for task [13844604206356789252](https://jules.google.com/task/13844604206356789252) started by @bashandbone*

## Summary by Sourcery

Remove unsafe eval-based git subtree execution in get-langs.sh and replace it with direct, safely-quoted command invocation.

Bug Fixes:
- Eliminate command injection risk in get-langs.sh by executing git subtree directly instead of via eval.

Enhancements:
- Improve logging around git subtree execution by clearly separating echo output from the actual command run and refining error messages.