### PR TITLE
⚡ [performance improvement] Defer PathBuf allocations in Tarjan's SCC DFS

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,6 @@
 ## 2026-04-08 - [Performance: Defer Allocation during Traversal]
 **Learning:** During DAG traversals, creating owned variants of identifiers (like `file.to_path_buf()`) *before* checking `visited` HashSets results in heap allocations (O(E)) for every edge instead of every visited node (O(V)). By moving the `&PathBuf` allocation strictly *after* all HashSet `contains` checks using the borrowed reference (`&Path`), we drastically reduce memory churn.
 **Action:** Always check `HashSet::contains` with a borrowed reference *before* creating the owned version required by `HashSet::insert`, especially in performance-critical graph traversal paths.
+## 2026-04-14 - [Performance: Avoid redundant `to_path_buf` in Hash lookups]
+**Learning:** In highly recursive functions like Tarjan's SCC DFS algorithm (`tarjan_dfs`), calling `.to_path_buf()` on `&Path` just to satisfy `.get()` or `.contains()` calls on HashMaps/Sets causes significant unnecessary heap allocation overhead (O(E) instead of O(V)).
+**Action:** When working with standard or custom hashing collections (like `RapidMap`, `RapidSet`, `std::collections::HashMap`), pass borrowed types (e.g., `&Path`) for lookups instead of allocating owned types (`PathBuf`). Only create the owned form when actually inserting into the collection, and create it exactly once per node visit.

--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -342,11 +342,12 @@ impl InvalidationDetector {
     fn tarjan_dfs(&self, v: &Path, state: &mut TarjanState, sccs: &mut Vec<Vec<PathBuf>>) {
         // Initialize node
         let index = state.index_counter;
-        state.indices.insert(v.to_path_buf(), index);
-        state.lowlinks.insert(v.to_path_buf(), index);
+        let v_buf = v.to_path_buf();
+        state.indices.insert(v_buf.clone(), index);
+        state.lowlinks.insert(v_buf.clone(), index);
         state.index_counter += 1;
-        state.stack.push(v.to_path_buf());
-        state.on_stack.insert(v.to_path_buf());
+        state.stack.push(v_buf.clone());
+        state.on_stack.insert(v_buf);
 
         // Visit all successors (dependencies)
         let dependencies = self.graph.get_dependencies(v);
@@ -358,19 +359,19 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();


### PR DESCRIPTION
💡 What
Replaced unnecessary owned `PathBuf` allocations (`.to_path_buf()`) within the `tarjan_dfs` graph traversal loop with borrowed `&Path` lookups inside `state.indices`, `state.lowlinks`, and `state.on_stack`.

🎯 Why
When dealing with HashMap/HashSet lookups in Rust, one should pass borrowed references if possible, rather than heap-allocating an owned item. In deeply recursive DAG invalidation scenarios (like Tarjan's algorithm finding SCCs), calling `v.to_path_buf()` strictly for `.get()` or `.contains()` calls added unnecessary `O(E)` heap allocations (since an edge lookup triggers it). Utilizing `std::collections::HashMap` capability to take a `&Path` drops these allocations to `0`, deferring any allocation solely to when nodes are first pushed to a stack or registered `O(V)`.

📊 Measured Improvement
Eliminates `O(E)` unnecessary heap allocations of `PathBuf` during strongly connected component detection in dependency graph invalidations.

🔬 Measurement
Verify via `cargo test -p thread-flow --test invalidation_tests` and benchmark improvements during graph SCC searches.

---
*PR created automatically by Jules for task [17336176359170230244](https://jules.google.com/task/17336176359170230244) started by @bashandbone*

## Summary by Sourcery

Optimize Tarjan SCC DFS invalidation traversal to eliminate redundant path allocations during hash lookups.

Enhancements:
- Reuse a single PathBuf per node visit in tarjan_dfs and perform HashMap/HashSet lookups using borrowed &Path keys to reduce allocation overhead.
- Expand internal performance notes in .jules/bolt.md with guidance on avoiding unnecessary owned path allocations in recursive graph algorithms.