### PR TITLE
⚡ Bolt: [performance improvement] optimize file path map lookups in invalidation detector

### DIFF
--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -358,19 +358,19 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
💡 What: Used borrowed `&Path` reference instead of owned `PathBuf` for HashMap existence and mutability checks in `tarjan_dfs`.
🎯 Why: Avoid O(E) unnecessary heap memory allocations of `PathBuf` within tight nested loops traversing nodes and edges of the invalidation graph.
📊 Impact: Considerably reduces memory pressure and allocation overhead during calculation of the increment invalidation sets.
🔬 Measurement: Verify using `cargo test -p thread-flow --test invalidation_tests`.

---
*PR created automatically by Jules for task [16106423400975348129](https://jules.google.com/task/16106423400975348129) started by @bashandbone*

## Summary by Sourcery

Optimize invalidation graph traversal to reduce allocation overhead and perform minor API and formatting cleanups.

Enhancements:
- Use borrowed path references for index and lowlink lookups in the incremental invalidation detector to avoid unnecessary allocations.
- Simplify rule-engine helper function signatures by removing unused lifetimes and taking borrowed references where appropriate.
- Tidy formatting and chaining style in string content handling, assertions, and registration map access for improved readability.