### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in TypeScript Module Resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-17 - [Path Traversal]
+**Vulnerability:** manual path resolution uses blind .pop()
+**Learning:** To prevent path traversal vulnerabilities when manually normalizing paths with std::path::Component (e.g., during module path resolution in crates/flow), explicitly block Component::ParentDir from popping Component::RootDir or Component::Prefix. If the components list is empty or its last element is Component::ParentDir, the new Component::ParentDir must be pushed rather than ignored to correctly preserve relative paths like ../../a.
+**Prevention:** Be careful with .pop() for ParentDir

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -807,9 +807,18 @@ impl TypeScriptDependencyExtractor {
                 let mut components = Vec::new();
                 for component in resolved.components() {
                     match component {
-                        std::path::Component::ParentDir => {
-                            components.pop();
-                        }
+                        std::path::Component::ParentDir => match components.last() {
+                            Some(std::path::Component::RootDir)
+                            | Some(std::path::Component::Prefix(_)) => {
+                                // Cannot go above root
+                            }
+                            Some(std::path::Component::Normal(_)) => {
+                                components.pop();
+                            }
+                            _ => {
+                                components.push(component);
+                            }
+                        },
                         std::path::Component::CurDir => {}
                         _ => components.push(component),
                     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `resolve_module_path` in `crates/flow/src/incremental/extractors/typescript.rs` used a blind `components.pop()` to handle `..` (`ParentDir`) components in manual path normalization. This was flawed because if the path started with `..`, or if `..` was evaluated against the root directory (`/`) or a drive prefix (`C:\`), it would improperly discard these important root or prefix components, potentially changing absolute paths to relative ones, escaping directories, or causing resolution mismatches.
🎯 Impact: Attackers could potentially exploit this manual path normalization behavior when parsing adversarial imports or files, allowing resolution outside of the intended extraction boundary, which is a classic path traversal risk.
🔧 Fix: Replaced the blind `.pop()` with a match statement on `components.last()`. It explicitly checks for `RootDir` and `Prefix` to prevent escaping above the root. It correctly pops `Normal` components, and it safely retains `ParentDir` (pushes it back onto the stack) when resolving at the root level of a relative path (e.g. `../../a`).
✅ Verification: Ran `cargo test -p thread-flow --test extractor_typescript_tests` which confirmed 25 module resolution tests passed with no regressions.

---
*PR created automatically by Jules for task [817992255317682365](https://jules.google.com/task/817992255317682365) started by @bashandbone*

## Summary by Sourcery

Fix path traversal handling in TypeScript module resolution by hardening manual path normalization and document the vulnerability and prevention guidance in Sentinel notes.

Bug Fixes:
- Correct parent directory component handling during manual path normalization to prevent escaping above filesystem roots or prefixes in TypeScript module resolution.

Documentation:
- Add Sentinel security note documenting the path traversal vulnerability, its root cause, and best practices for safe path normalization.