### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in manual TS module path resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Path Traversal in Manual Path Normalization]
+**Vulnerability:** Manual path resolution using `components.pop()` on `std::path::Component::ParentDir` allowed path traversal. If a path like `../../a` was parsed, `components.pop()` on an empty `Vec` did nothing, turning the path into `a` instead of preserving the parent traversal. It could also pop `RootDir` or `Prefix` components, changing absolute paths to relative ones or traversing beyond intended roots.
+**Learning:** `std::path::Component` normalization must handle empty lists and consecutive `ParentDir` components by pushing them instead of ignoring them. It must also explicitly avoid popping `RootDir` or `Prefix` components to prevent escaping virtual file systems or simulated root directories.
+**Prevention:** Explicitly check if the `components` list is empty, if the last component is `ParentDir`, or if the last component is `RootDir` / `Prefix` before calling `pop()`.

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,18 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            let is_empty = components.is_empty();
+                            let last_is_parent = matches!(components.last(), Some(std::path::Component::ParentDir));
+                            let last_is_root_or_prefix = matches!(
+                                components.last(),
+                                Some(std::path::Component::RootDir) | Some(std::path::Component::Prefix(_))
+                            );
+
+                            if is_empty || last_is_parent {
+                                components.push(component);
+                            } else if !last_is_root_or_prefix {
+                                components.pop();
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A path traversal vulnerability existed in the manual path normalization fallback logic within `TypeScriptDependencyExtractor::resolve_module_path` in `crates/flow/src/incremental/extractors/typescript.rs`. The logic used `components.pop()` incorrectly when encountering `std::path::Component::ParentDir`. If it was passed consecutive `..` directories, or paths leading back up out of the virtual resolution root, it could either mistakenly ignore them entirely, or it could pop `RootDir` and `Prefix` components, effectively breaking out of intended boundaries.
🎯 Impact: It could cause incorrect relative module resolution, either masking dependencies, creating erroneous dependency edges outside of the project folder structure, or in specific cases exposing the internal path structure.
🔧 Fix: Updated the component reduction logic to push `ParentDir` onto the vector if the vector is empty, if the previous component was a `ParentDir`, and prevented popping if the previous component was a `RootDir` or `Prefix`.
✅ Verification: Ran `cargo test -p thread-flow` unit tests and standard incremental tests successfully without regression.

---
*PR created automatically by Jules for task [16283416882480453920](https://jules.google.com/task/16283416882480453920) started by @bashandbone*

## Summary by Sourcery

Fix TypeScript dependency extraction path normalization to prevent path traversal and document the vulnerability in Sentinel notes.

Bug Fixes:
- Correct manual path normalization for TypeScript module resolution to safely handle parent directory components without escaping the intended root.

Documentation:
- Add Sentinel security note documenting the path traversal vulnerability, its root cause, and prevention guidelines.