### PR TITLE
⚡ Bolt: [performance improvement] Reduce O(E) allocation churn in graph construction

### DIFF
--- a/crates/flow/src/incremental/graph.rs
+++ b/crates/flow/src/incremental/graph.rs
@@ -177,14 +177,17 @@ impl DependencyGraph {
         self.ensure_node(&edge.to);
 
         // Update adjacency lists
-        self.forward_adj
-            .entry(edge.from.clone())
-            .or_default()
-            .push(idx);
-        self.reverse_adj
-            .entry(edge.to.clone())
-            .or_default()
-            .push(idx);
+        if let Some(vec) = self.forward_adj.get_mut(&edge.from) {
+            vec.push(idx);
+        } else {
+            self.forward_adj.insert(edge.from.clone(), vec![idx]);
+        }
+
+        if let Some(vec) = self.reverse_adj.get_mut(&edge.to) {
+            vec.push(idx);
+        } else {
+            self.reverse_adj.insert(edge.to.clone(), vec![idx]);
+        }
 
         self.edges.push(edge);
 
@@ -400,9 +403,10 @@ impl DependencyGraph {
     /// Ensures a node exists in the graph for the given file path.
     /// Creates a default fingerprint entry if the node does not exist.
     fn ensure_node(&mut self, file: &Path) {
-        self.nodes
-            .entry(file.to_path_buf())
-            .or_insert_with(|| AnalysisDefFingerprint::new(b""));
+        if !self.nodes.contains_key(file) {
+            self.nodes
+                .insert(file.to_path_buf(), AnalysisDefFingerprint::new(b""));
+        }
     }
 
     /// DFS visit for topological sort with cycle detection.

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);


### PR DESCRIPTION
### 💡 What
Replaced expensive `.entry().or_insert()` and `.entry().or_default()` uses in `crates/flow/src/incremental/graph.rs` with `.contains_key()` and `.get_mut()` checks to eliminate redundant `PathBuf` string clones. 

### 🎯 Why
During graph construction (`ensure_node` and `add_edge`), `entry(key.clone())` unconditionally allocates and clones strings even if the key is already present in the HashMap. In large codebases with heavily connected dependency graphs, this results in significant O(E) memory churn.

### 📊 Impact
Changes allocations from O(E) to O(V). It greatly reduces memory allocation pressure and improves speed during full-graph dependency updates and analysis cycles.

### 🔬 Measurement
Run `cargo bench -p thread-flow --bench graph_bench` or profile the application graph builder. Graph insertion times should be tangibly lower and `jemalloc` should report significantly reduced allocation volume inside `DependencyGraph::add_edge`.

---
*PR created automatically by Jules for task [8275981448862509516](https://jules.google.com/task/8275981448862509516) started by @bashandbone*

## Summary by Sourcery

Optimize graph construction performance and simplify rule-engine helper signatures.

Enhancements:
- Reduce allocation churn in dependency graph edge and node insertion by avoiding unnecessary HashMap entry cloning.
- Simplify rule-engine constraint and transform variable-check helpers by removing redundant lifetime annotations in their function signatures.