### PR TITLE
⚡ Bolt: [performance improvement] eliminate redundant path allocations in DAG traversals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 ## 2026-04-08 - [Performance: Defer Allocation during Traversal]
 **Learning:** During DAG traversals, creating owned variants of identifiers (like `file.to_path_buf()`) *before* checking `visited` HashSets results in heap allocations (O(E)) for every edge instead of every visited node (O(V)). By moving the `&PathBuf` allocation strictly *after* all HashSet `contains` checks using the borrowed reference (`&Path`), we drastically reduce memory churn.
 **Action:** Always check `HashSet::contains` with a borrowed reference *before* creating the owned version required by `HashSet::insert`, especially in performance-critical graph traversal paths.
+
+## 2024-04-22 - [Performance: Avoid redundant PathBuf allocations in DFS lookup paths]
+**Learning:** In DAG traversal algorithms (like Tarjan's SCC in `crates/flow/src/incremental/invalidation.rs`), calling `.to_path_buf()` on borrowed `&Path` values purely for HashMap lookups triggers repeated heap allocations in O(E) dependency loops.
+**Action:** Use Rust's `Borrow` trait by passing the raw `&Path` reference directly into `HashMap::get` and `HashMap::get_mut`. Allocate `PathBuf` once per node via `.clone()` ONLY when inserting data into the map or stack, achieving O(1) allocation during lookup steps.

--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -342,11 +342,12 @@ impl InvalidationDetector {
     fn tarjan_dfs(&self, v: &Path, state: &mut TarjanState, sccs: &mut Vec<Vec<PathBuf>>) {
         // Initialize node
         let index = state.index_counter;
-        state.indices.insert(v.to_path_buf(), index);
-        state.lowlinks.insert(v.to_path_buf(), index);
+        let v_buf = v.to_path_buf();
+        state.indices.insert(v_buf.clone(), index);
+        state.lowlinks.insert(v_buf.clone(), index);
         state.index_counter += 1;
-        state.stack.push(v.to_path_buf());
-        state.on_stack.insert(v.to_path_buf());
+        state.stack.push(v_buf.clone());
+        state.on_stack.insert(v_buf);
 
         // Visit all successors (dependencies)
         let dependencies = self.graph.get_dependencies(v);
@@ -358,19 +359,19 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();


### PR DESCRIPTION
💡 **What:** Eliminated repetitive O(E) heap allocations for `PathBuf` lookups inside `tarjan_dfs` by relying on Rust's `Borrow` trait for `.get()` and `.get_mut()` lookups using the borrowed `&Path` reference.
🎯 **Why:** Creating an owned `PathBuf` purely to look up a value inside a `HashMap` is extremely inefficient during graph traversals as it allocates memory repeatedly for the same string value across every edge visited.
📊 **Impact:** Reduces redundant heap allocations in `tarjan_dfs` from O(Edges) to strictly O(Nodes), lowering execution time and memory fragmentation for larger dependency graphs.
🔬 **Measurement:** Verify functionality and absence of regressions using `cargo test -p thread-flow --test invalidation_tests` and `cargo clippy`.

---
*PR created automatically by Jules for task [7373454954958409554](https://jules.google.com/task/7373454954958409554) started by @bashandbone*

## Summary by Sourcery

Optimize Tarjan SCC traversal to reduce redundant path allocations during invalidation analysis.

Enhancements:
- Reduce PathBuf allocations in tarjan_dfs by reusing a single owned path per node and using borrowed &Path for HashMap lookups.

Documentation:
- Extend .jules/bolt.md with guidance on avoiding redundant PathBuf allocations in DFS-based DAG traversal lookups.