### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in module resolution

### DIFF
--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,22 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            if let Some(last) = components.last() {
+                                match last {
+                                    std::path::Component::RootDir
+                                    | std::path::Component::Prefix(_) => {
+                                        // Ignore ParentDir at root to prevent path traversal
+                                    }
+                                    std::path::Component::ParentDir => {
+                                        components.push(component);
+                                    }
+                                    _ => {
+                                        components.pop();
+                                    }
+                                }
+                            } else {
+                                components.push(component);
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path normalization logic allowed `Component::ParentDir` to pop `RootDir` or `Prefix` and make absolute paths relative. Attackers could craft relative import strings (`../../../etc/passwd`) that escape project boundaries and are resolved against unintended root locations.
🎯 **Impact:** Arbitrary local file inclusion and path traversal logic, leading to the risk of sensitive files being read or executed by module loaders or system tools dependent on resolving module specifiers.
🔧 **Fix:** Explicitly restricted the path normalization logic in `typescript.rs`. The code now actively checks the last component, and skips the pop logic if `ParentDir` tries to traverse beyond `RootDir` or `Prefix`. If the component vector is empty or already ends with `ParentDir`, the `ParentDir` is pushed.
✅ **Verification:** Verified by passing tests locally in `extractor_typescript_tests`. Tested that normal resolving still functions and there are no regressions.

---
*PR created automatically by Jules for task [11299775835637984422](https://jules.google.com/task/11299775835637984422) started by @bashandbone*

## Summary by Sourcery

Fix path normalization to prevent directory traversal beyond root in TypeScript module resolution and apply minor code formatting cleanups.

Bug Fixes:
- Prevent ParentDir components from escaping root or prefix during TypeScript path normalization, closing a path traversal issue in module resolution.

Enhancements:
- Apply minor formatting and readability cleanups in AST engine and rule engine code paths.