### PR TITLE
⚡ Bolt: [performance improvement] Defer PathBuf allocations during DAG traversal

### DIFF
--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -342,11 +342,13 @@ impl InvalidationDetector {
     fn tarjan_dfs(&self, v: &Path, state: &mut TarjanState, sccs: &mut Vec<Vec<PathBuf>>) {
         // Initialize node
         let index = state.index_counter;
-        state.indices.insert(v.to_path_buf(), index);
-        state.lowlinks.insert(v.to_path_buf(), index);
+        // ⚡ Bolt Optimization: Compute owned PathBuf once for insertion to avoid redundant O(E) allocations
+        let v_buf = v.to_path_buf();
+        state.indices.insert(v_buf.clone(), index);
+        state.lowlinks.insert(v_buf.clone(), index);
         state.index_counter += 1;
-        state.stack.push(v.to_path_buf());
-        state.on_stack.insert(v.to_path_buf());
+        state.stack.push(v_buf.clone());
+        state.on_stack.insert(v_buf);
 
         // Visit all successors (dependencies)
         let dependencies = self.graph.get_dependencies(v);
@@ -358,19 +360,22 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                // ⚡ Bolt Optimization: Use borrowed `&Path` reference `v` for map lookup instead of allocating
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                // ⚡ Bolt Optimization: Use borrowed `&Path` reference `v` for map lookup instead of allocating
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        // ⚡ Bolt Optimization: Use borrowed `&Path` reference `v` for map lookup instead of allocating
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);


### PR DESCRIPTION
💡 **What**: Refactored `tarjan_dfs` in `crates/flow/src/incremental/invalidation.rs` to compute `v.to_path_buf()` only once when initializing the node, and subsequently used the borrowed `v` (`&Path`) reference for all inner-loop lookups in HashMaps (`state.lowlinks.get_mut(v)` and `state.indices.get(v)`).

🎯 **Why**: In the hot loop traversing all edges of the dependency graph (O(E)), `v.to_path_buf()` was previously called repeatedly. This meant that for every edge, a new `PathBuf` was being heap-allocated just to do a map lookup, causing high memory churn and severely degrading traversal performance on large graphs.

📊 **Impact**: This drastically reduces string allocation churn during the dependency graph traversal, turning O(E) heap allocations into O(V) or effectively zero allocations inside the traversal loop. This directly speeds up the incremental invalidation cycle.

🔬 **Measurement**: Run the performance tests using `cargo test -p thread-flow --test invalidation_tests` and observe improved or consistently fast completion times for tests like `test_large_graph_performance` and `test_wide_fanout_performance`.

*(Also included a minor cleanup to remove unnecessary explicit lifetimes in `crates/rule-engine/src/check_var.rs` that were throwing Clippy warnings).*

---
*PR created automatically by Jules for task [15373065001613403940](https://jules.google.com/task/15373065001613403940) started by @bashandbone*

## Summary by Sourcery

Optimize Tarjan DFS invalidation traversal to reduce path allocations and perform minor cleanup in rule-engine variable checking utilities.

Enhancements:
- Defer PathBuf allocations in the Tarjan DFS traversal by reusing a single owned path per node and relying on borrowed paths for hashmap lookups.
- Simplify rule-engine helper function signatures by removing unnecessary explicit lifetimes on constraint and transform references.