### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in TS Extractor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-30 - Fix Path Traversal in TS Extractor Manual Path Resolution
+**Vulnerability:** Path traversal possible via `../` sequences during manual resolution of TypeScript import specifiers in `crates/flow/src/incremental/extractors/typescript.rs` due to blindly popping the component stack.
+**Learning:** `std::path::Component::ParentDir` must be handled explicitly depending on the state of the stack. Blindly calling `.pop()` on the component vector allows maliciously crafted import paths like `../../../../sensitive_file` to escape the source tree or prefix directories if `canonicalize` falls back to manual parsing.
+**Prevention:** Always use safe path normalization. When manually popping components on `ParentDir`, check `components.last()`. Ignore if `RootDir` or `Prefix`. If `None` or already a `ParentDir`, push it. Only pop if it's a `Normal` component.

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -807,9 +807,15 @@ impl TypeScriptDependencyExtractor {
                 let mut components = Vec::new();
                 for component in resolved.components() {
                     match component {
-                        std::path::Component::ParentDir => {
-                            components.pop();
-                        }
+                        std::path::Component::ParentDir => match components.last() {
+                            Some(std::path::Component::RootDir)
+                            | Some(std::path::Component::Prefix(_)) => {}
+                            Some(std::path::Component::ParentDir) => components.push(component),
+                            Some(_) => {
+                                components.pop();
+                            }
+                            None => components.push(component),
+                        },
                         std::path::Component::CurDir => {}
                         _ => components.push(component),
                     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal during fallback manual path resolution for TypeScript module imports. The code unconditionally popped items off the component vector whenever a `../` (`ParentDir`) was encountered. Malicious import patterns could escape the intended directory confines and escape out of the project root.
🎯 Impact: Attackers could supply maliciously crafted module specifiers causing the dependency graph extractor to index or expose sensitive files far outside the intended working directory context.
🔧 Fix: Adopted secure path resolution in `crates/flow/src/incremental/extractors/typescript.rs` by checking `components.last()`. It refuses to pop `RootDir` or `Prefix` and pushes `ParentDir` if at the beginning of the relative boundary.
✅ Verification: Ran `cargo test -p thread-flow --test extractor_typescript_tests` which confirmed 25 passing tests, along with `cargo +nightly fmt` and `cargo clippy`. Also created Sentinel journal entry outlining the learning.

---
*PR created automatically by Jules for task [3856840533023296548](https://jules.google.com/task/3856840533023296548) started by @bashandbone*

## Summary by Sourcery

Harden TypeScript dependency extraction path normalization to prevent directory traversal and document the vulnerability and its remediation in the Sentinel journal.

Bug Fixes:
- Prevent path traversal during manual resolution of TypeScript module import paths by safely handling parent directory components.

Documentation:
- Add a Sentinel journal entry describing the TypeScript extractor path traversal vulnerability, its cause, and the adopted safe path normalization approach.