### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in file resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Prevent Path Traversal by blocking parent popping of prefix/root in path component manipulation
+**Vulnerability:** In `crates/flow/src/incremental/extractors/typescript.rs` and potentially elsewhere, path normalization popped standard components blindly when encountering `Component::ParentDir`. This could allow relative paths to evaluate to dangerous arbitrary paths.
+**Learning:** Path normalization routines built on top of `std::path::Component` iterations must verify the previous component before popping it for a parent directory escape. `Component::ParentDir` should push to the component stack if the stack is empty, only has another `ParentDir`, or if the last element is `Prefix` or `RootDir` it should be ignored.
+**Prevention:** In loops managing components, match on `components.last()` during a `ParentDir` to ensure we do not `pop` root directories or prefixes.

--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -804,12 +804,19 @@ impl TypeScriptDependencyExtractor {
                 resolved = canonical;
             } else {
                 // If canonicalize fails (file doesn't exist), manually resolve
-                let mut components = Vec::new();
+                let mut components: Vec<std::path::Component> = Vec::new();
                 for component in resolved.components() {
                     match component {
-                        std::path::Component::ParentDir => {
-                            components.pop();
-                        }
+                        std::path::Component::ParentDir => match components.last() {
+                            Some(std::path::Component::Prefix(_))
+                            | Some(std::path::Component::RootDir) => {}
+                            Some(std::path::Component::ParentDir) | None => {
+                                components.push(component);
+                            }
+                            _ => {
+                                components.pop();
+                            }
+                        },
                         std::path::Component::CurDir => {}
                         _ => components.push(component),
                     }

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** When manually resolving file paths with `std::path::Component`, `Component::ParentDir` was unconditionally popping the last component of the vector. If a malicious or malformed string evaluates with parent navigations that hit `Prefix` (`C:\`) or `RootDir` (`/`), it incorrectly popped those security boundaries off the stack, enabling potential path traversal.
🎯 **Impact:** Allowed maliciously crafted input paths to escape bounds, converting safe absolute paths into relative arbitrary accesses.
🔧 **Fix:** Changed path component traversal logic to match the end of the `components` vector; explicitly ignoring pops if the top of stack is a root or prefix, and safely accumulating parent traversal for relative structures.
✅ **Verification:** Validated that test cases passing malformed absolute traversal inputs are resolved safely without directory escape. Ran both `cargo fmt` and `cargo clippy` and ran the relevant TypeScript extraction tests and library tests locally.

---
*PR created automatically by Jules for task [16129905665493744072](https://jules.google.com/task/16129905665493744072) started by @bashandbone*

## Summary by Sourcery

Fix unsafe path normalization in TypeScript dependency extraction to prevent path traversal when resolving non-canonicalized file paths.

Bug Fixes:
- Prevent parent directory components from popping root or prefix segments during manual path resolution, avoiding traversal outside intended directories.

Enhancements:
- Apply minor Rust code cleanups and type signature simplifications in AST and rule engine modules for improved readability.

Documentation:
- Add Sentinel security note documenting the path traversal vulnerability, its root cause, and recommended prevention patterns for path normalization logic.