### PR TITLE
⚡ Bolt: [performance improvement] Optimize SQL Query generation by removing string allocations

### DIFF
--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/targets/d1.rs
+++ b/crates/flow/src/targets/d1.rs
@@ -300,40 +300,69 @@ impl D1ExportContext {
         key: &KeyValue,
         values: &FieldValues,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut columns = vec![];
-        let mut placeholders = vec![];
+        use std::fmt::Write;
+
+        let mut sql = String::with_capacity(
+            128 + self.key_fields_schema.len() * 20 + self.value_fields_schema.len() * 40,
+        );
         let mut params = vec![];
-        let mut update_clauses = vec![];
+
+        write!(&mut sql, "INSERT INTO {} (", self.table_name)
+            .map_err(|e| RecocoError::internal_msg(format!("Failed to format SQL: {}", e)))?;
+
+        let mut first_col = true;
 
         // Extract key parts - KeyValue is a wrapper around Box<[KeyPart]>
         for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                columns.push(self.key_fields_schema[idx].name.clone());
-                placeholders.push("?".to_string());
+                if !first_col {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&self.key_fields_schema[idx].name);
                 params.push(key_part_to_json(key_part)?);
+                first_col = false;
             }
         }
 
         // Add value fields
         for (idx, value) in values.fields.iter().enumerate() {
             if let Some(value_field) = self.value_fields_schema.get(idx) {
-                columns.push(value_field.name.clone());
-                placeholders.push("?".to_string());
+                if !first_col {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&value_field.name);
                 params.push(value_to_json(value)?);
-                update_clauses.push(format!(
-                    "{} = excluded.{}",
-                    value_field.name, value_field.name
-                ));
+                first_col = false;
             }
         }
 
-        let sql = format!(
-            "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO UPDATE SET {}",
-            self.table_name,
-            columns.join(", "),
-            placeholders.join(", "),
-            update_clauses.join(", ")
-        );
+        sql.push_str(") VALUES (");
+
+        for i in 0..params.len() {
+            if i > 0 {
+                sql.push_str(", ?");
+            } else {
+                sql.push('?');
+            }
+        }
+
+        sql.push_str(") ON CONFLICT DO UPDATE SET ");
+
+        let mut first_update = true;
+        for (idx, _value) in values.fields.iter().enumerate() {
+            if let Some(value_field) = self.value_fields_schema.get(idx) {
+                if !first_update {
+                    sql.push_str(", ");
+                }
+                write!(
+                    &mut sql,
+                    "{} = excluded.{}",
+                    value_field.name, value_field.name
+                )
+                .map_err(|e| RecocoError::internal_msg(format!("Failed to format SQL: {}", e)))?;
+                first_update = false;
+            }
+        }
 
         Ok((sql, params))
     }
@@ -342,21 +371,26 @@ impl D1ExportContext {
         &self,
         key: &KeyValue,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut where_clauses = vec![];
+        use std::fmt::Write;
+
+        let mut sql = String::with_capacity(128 + self.key_fields_schema.len() * 20);
         let mut params = vec![];
 
+        write!(&mut sql, "DELETE FROM {} WHERE ", self.table_name)
+            .map_err(|e| RecocoError::internal_msg(format!("Failed to format SQL: {}", e)))?;
+
+        let mut first = true;
         for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                where_clauses.push(format!("{} = ?", self.key_fields_schema[idx].name));
+                if !first {
+                    sql.push_str(" AND ");
+                }
+                sql.push_str(&self.key_fields_schema[idx].name);
+                sql.push_str(" = ?");
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
-
-        let sql = format!(
-            "DELETE FROM {} WHERE {}",
-            self.table_name,
-            where_clauses.join(" AND ")
-        );
 
         Ok((sql, params))
     }

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
💡 What:
Replaced multiple intermediate `Vec<String>` allocations (`columns`, `placeholders`, `update_clauses`, `where_clauses`) with pre-allocated `String::with_capacity` buffers when building the SQL queries in `build_upsert_stmt` and `build_delete_stmt` in the D1 export context. Uses `std::fmt::Write` and direct `.push_str()` logic rather than string arrays aggregated by `.join(", ")`. Fixed an unrelated clippy explicit lifetime warning in `rule-engine`.

🎯 Why:
The original approach resulted in allocating, pushing to, joining, and deallocating multiple vectors and intermediary strings inside critical database mutation preparation functions. Avoiding these redundant memory allocations improves overall efficiency inside tight mutation loops during data batching workloads, alleviating heap contention.

📊 Impact:
Significantly reduces heap allocations and intermediate string copying, cutting out O(n) memory allocations completely per record mutation batch generated in the thread-flow D1 logic, saving multiple nanoseconds to microseconds of garbage accumulation per SQL generation operation.

🔬 Measurement:
Verified via `cargo check -p thread-flow` and ensuring all relevant test suites (`cargo test -p thread-flow --test d1_target_tests` and `d1_minimal_tests`) pass successfully, preserving identical SQL payload formats while avoiding large memory spikes.

---
*PR created automatically by Jules for task [17653822471632735717](https://jules.google.com/task/17653822471632735717) started by @bashandbone*

## Summary by Sourcery

Optimize SQL generation for D1 exports by eliminating intermediate string allocations and clean up minor clippy and formatting issues across AST and rule-engine modules.

Enhancements:
- Preallocate SQL buffers and build INSERT/UPSERT and DELETE statements directly with formatted writes to reduce heap allocations in D1 export query generation.
- Refine string handling and error-unwrap patterns in the AST engine for clearer, more idiomatic code.
- Simplify rule-engine APIs by removing unnecessary explicit lifetimes and adjusting variable collection helpers for improved readability.