### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in manual path normalization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-09 - Prevent Path Traversal in Manual Path Resolution
+**Vulnerability:** The TypeScript dependency extractor (`crates/flow/src/incremental/extractors/typescript.rs`) manually normalized paths without preventing `ParentDir` components from popping `RootDir` or `Prefix`, allowing paths to escape the intended directory.
+**Learning:** Manual path normalization (e.g., when `canonicalize()` fails) must strictly handle standard library boundaries like `RootDir` and `Prefix` to prevent path traversal outside of absolute or project boundaries.
+**Prevention:** Always check if the path component being popped represents a boundary, or use robust external path normalization libraries instead of rolling custom loops with `std::path::Component`.

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,20 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            let is_empty = components.is_empty();
+                            let is_parent = matches!(
+                                components.last(),
+                                Some(std::path::Component::ParentDir)
+                            );
+                            let is_root = matches!(
+                                components.last(),
+                                Some(std::path::Component::RootDir | std::path::Component::Prefix(_))
+                            );
+                            if is_empty || is_parent {
+                                components.push(component);
+                            } else if !is_root {
+                                components.pop();
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal vulnerability in `TypeScriptDependencyExtractor`. When `canonicalize()` fails, manual path normalization blindly popped components when encountering `..` (`ParentDir`), potentially popping `RootDir` or `Prefix` and escaping boundary restrictions, or ignoring `..` entirely at the root of a relative path.
🎯 **Impact:** An attacker could potentially extract dependencies or access files outside of the intended directory context via maliciously crafted import paths containing excessive `..` components.
🔧 **Fix:** Updated the manual `std::path::Component` loop to securely handle `ParentDir` by: (1) pushing it if the current component list is empty or already ends in `ParentDir`, and (2) not popping if the current end is `RootDir` or `Prefix`.
✅ **Verification:** Ran `cargo check -p thread-flow` and verified functionality via `cargo test -p thread-flow --test extractor_typescript_tests`. Both compile and pass perfectly.

---
*PR created automatically by Jules for task [1072408770329239754](https://jules.google.com/task/1072408770329239754) started by @bashandbone*

## Summary by Sourcery

Harden TypeScript dependency extraction path normalization to prevent directory traversal and document the incident and remediation in Sentinel notes.

Bug Fixes:
- Prevent manual path normalization from allowing `..` components to escape root or prefix boundaries in the TypeScript dependency extractor.

Documentation:
- Add a Sentinel incident entry describing the path traversal vulnerability, its cause, and prevention guidelines.