### PR TITLE
⚡ Bolt: [performance improvement] optimize path allocations in incremental invalidation

### DIFF
--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -358,19 +358,22 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                // Bolt: Use borrowed `&Path` instead of `&v.to_path_buf()` to avoid O(E) heap allocations during traversal
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                // Bolt: Use borrowed `&Path` instead of `&v.to_path_buf()` to avoid O(E) heap allocations during traversal
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        // Bolt: Use borrowed `&Path` instead of `&v.to_path_buf()` to avoid heap allocations
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);


### PR DESCRIPTION
💡 What: Removed `&v.to_path_buf()` calls in `crates/flow/src/incremental/invalidation.rs` map queries (`get_mut` and `get`), using borrowed `v` instead. Cleaned up explicit lifetime lint warnings in `check_var.rs` along the way.
🎯 Why: `&v.to_path_buf()` allocates a new string-backed Path on the heap. Doing this inside Tarjan's strongly-connected-components inner loop (graph edges) resulted in `O(E)` memory churn per graph connected component calculation. Borrowing allows us to look up references instantly in RapidMap without allocations.
📊 Impact: Faster invalidation propagation algorithms with lower peak memory footprint on deeply-connected component graphs.
🔬 Measurement: Verified via memory correctness traces (`test_get.rs` checks) and `cargo test -p thread-flow --test invalidation_tests`. All SCC, topological, and tree validation checks passed successfully.

---
*PR created automatically by Jules for task [968163309968730354](https://jules.google.com/task/968163309968730354) started by @bashandbone*

## Summary by Sourcery

Optimize incremental invalidation graph traversal to reduce path allocation overhead and clean up lifetime usage in variable checking utilities.

Enhancements:
- Reuse borrowed Path references in Tarjan SCC indices/lowlink maps to avoid repeated PathBuf allocations during invalidation traversal.
- Simplify function signatures in variable constraint/transform checks by removing unnecessary explicit lifetimes and using reference types directly.