### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate string instead of vector join in D1 UPSERTs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,6 @@
 ## 2026-04-08 - [Performance: Defer Allocation during Traversal]
 **Learning:** During DAG traversals, creating owned variants of identifiers (like `file.to_path_buf()`) *before* checking `visited` HashSets results in heap allocations (O(E)) for every edge instead of every visited node (O(V)). By moving the `&PathBuf` allocation strictly *after* all HashSet `contains` checks using the borrowed reference (`&Path`), we drastically reduce memory churn.
 **Action:** Always check `HashSet::contains` with a borrowed reference *before* creating the owned version required by `HashSet::insert`, especially in performance-critical graph traversal paths.
+## 2026-04-10 - [Performance: SQL Generation without intermediate strings]
+**Learning:** SQL string generation inside loops heavily allocates intermediate strings when using Vec<String>::join. Since Cloudflare D1 targets are frequently accessed and performance is critical for network-bound operations, we must optimize format string generation.
+**Action:** Use std::fmt::Write to append to a pre-allocated String instead of pushing formatting strings and joining them later to reduce string allocations.

--- a/crates/flow/src/targets/d1.rs
+++ b/crates/flow/src/targets/d1.rs
@@ -300,40 +300,47 @@ impl D1ExportContext {
         key: &KeyValue,
         values: &FieldValues,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut columns = vec![];
-        let mut placeholders = vec![];
-        let mut params = vec![];
-        let mut update_clauses = vec![];
+        use std::fmt::Write;
+        let expected_params = self.key_fields_schema.len() + self.value_fields_schema.len();
+        let mut params = Vec::with_capacity(expected_params);
 
-        // Extract key parts - KeyValue is a wrapper around Box<[KeyPart]>
-        for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
+        // Optimize SQL generation: pre-allocate capacity to avoid intermediate Strings and allocations
+        let mut sql = String::with_capacity(64 + self.table_name.len() + (expected_params * 32));
+        write!(&mut sql, "INSERT INTO {} (", self.table_name).unwrap();
+
+        let mut first = true;
+        for (idx, key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                columns.push(self.key_fields_schema[idx].name.clone());
-                placeholders.push("?".to_string());
+                if !first { sql.push_str(", "); }
+                sql.push_str(&key_field.name);
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
-
-        // Add value fields
         for (idx, value) in values.fields.iter().enumerate() {
             if let Some(value_field) = self.value_fields_schema.get(idx) {
-                columns.push(value_field.name.clone());
-                placeholders.push("?".to_string());
+                if !first { sql.push_str(", "); }
+                sql.push_str(&value_field.name);
                 params.push(value_to_json(value)?);
-                update_clauses.push(format!(
-                    "{} = excluded.{}",
-                    value_field.name, value_field.name
-                ));
+                first = false;
             }
         }
 
-        let sql = format!(
-            "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO UPDATE SET {}",
-            self.table_name,
-            columns.join(", "),
-            placeholders.join(", "),
-            update_clauses.join(", ")
-        );
+        sql.push_str(") VALUES (");
+        for i in 0..params.len() {
+            if i > 0 { sql.push_str(", "); }
+            sql.push('?');
+        }
+
+        sql.push_str(") ON CONFLICT DO UPDATE SET ");
+        let mut first = true;
+        for (idx, _value) in values.fields.iter().enumerate() {
+            if let Some(value_field) = self.value_fields_schema.get(idx) {
+                if !first { sql.push_str(", "); }
+                write!(&mut sql, "{0} = excluded.{0}", value_field.name).unwrap();
+                first = false;
+            }
+        }
 
         Ok((sql, params))
     }


### PR DESCRIPTION
**💡 What**
Optimized the `build_upsert_stmt` function in `crates/flow/src/targets/d1.rs` by refactoring it to directly write to a single pre-allocated `String` buffer using `std::fmt::Write`. This replaces the previous implementation that allocated multiple intermediate vectors (`columns`, `placeholders`, `update_clauses`) and created temporary Strings before joining them all at the end.

**🎯 Why**
Generating D1 queries happens on a very hot codepath when writing data back to Cloudflare D1 endpoints. The existing approach created multiple intermediate string allocations and vector resize churn per statement. For large tables or frequent updates, these unnecessary heap allocations create measurable memory overhead and GC pressure (if tracking). Writing directly to a buffer with pre-calculated capacity prevents this bottleneck.

**📊 Impact**
Reduces memory allocation overhead for UPSERT generation from O(N) intermediate structures (where N is the number of keys + values) down to O(1) buffer allocations per query. 

**🔬 Measurement**
Verified functionality using `cargo test -p thread-flow` to ensure the dynamically generated SQL exactly matches the expected format, and verified performance improvement theoretically by preventing at least 4 vectors and ~3N string allocations per call. Recorded performance learnings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [342063582730952543](https://jules.google.com/task/342063582730952543) started by @bashandbone*

## Summary by Sourcery

Optimize D1 UPSERT SQL generation to reduce string allocations and improve performance on a hot path.

Enhancements:
- Refactor D1 UPSERT statement builder to write directly into a pre-allocated SQL String buffer instead of constructing and joining intermediate vectors.
- Pre-size parameter and SQL buffers based on schema to minimize heap allocations during UPSERT generation.

Documentation:
- Document performance learnings about SQL generation without intermediate strings in .jules/bolt.md.