### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in TypeScript Module Resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-12 - Path Traversal Vulnerability in TypeScript Module Resolution
+**Vulnerability:** The manual path resolution for `../` module specifiers in `TypeScriptExtractor::resolve_module_path` was popping `components` unconditionally on `Component::ParentDir`. This means `../../a` might consume `Component::RootDir` or `Component::Prefix`, causing a path traversal vulnerability and incorrect normalization when there are no more components to pop.
+**Learning:** `std::path::Component::ParentDir` must explicitly block popping `Component::RootDir` or `Component::Prefix`. Furthermore, if the components list is empty or the last element is already `Component::ParentDir`, we must push the `Component::ParentDir` instead of doing nothing or attempting to pop.
+**Prevention:** When doing manual path normalization with `std::path::Component`, always use pattern matching on the last component before popping to ensure root boundaries and relative navigation are preserved.

--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,21 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            if let Some(
+                                std::path::Component::RootDir | std::path::Component::Prefix(_),
+                            ) = components.last()
+                            {
+                                // Cannot go above root
+                            } else if components.is_empty()
+                                || matches!(
+                                    components.last(),
+                                    Some(std::path::Component::ParentDir)
+                                )
+                            {
+                                components.push(component);
+                            } else {
+                                components.pop();
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The manual path normalization for `../` in `TypeScriptExtractor::resolve_module_path` was insecure. It unconditionally popped the last component from the path when encountering `Component::ParentDir`. This meant that a path like `../../a` might consume a root boundary (`Component::RootDir`) or `Component::Prefix`, causing a path traversal vulnerability that escaped intended boundaries and resulted in incorrect normalizations.
🎯 Impact: An attacker or malformed import string could bypass directory containment by exploiting the faulty `../` resolution, potentially exposing or targeting files outside the authorized module structure.
🔧 Fix: Updated the match arm for `std::path::Component::ParentDir` to ensure we explicitly guard against popping `RootDir` and `Prefix`. Additionally, if the components list is empty or the last component is already `ParentDir`, we now properly push the new `ParentDir` onto the vector.
✅ Verification: Ran `cargo test -p thread-flow --test extractor_typescript_tests` which confirmed modules resolved correctly. Verified formatting and clippy lints passed. Logged vulnerability to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9830579213628566746](https://jules.google.com/task/9830579213628566746) started by @bashandbone*

## Summary by Sourcery

Fix unsafe parent-directory handling in TypeScript module resolution and perform minor code cleanups across AST and rule engine modules.

Bug Fixes:
- Prevent path traversal by guarding against popping root or prefix components when resolving parent directory segments in TypeScript module paths.

Enhancements:
- Simplify generics and reference types in rule engine variable checking utilities.
- Tidy up string conversion, cloning, and pattern-variant handling in AST and rule engine modules for improved readability.

Documentation:
- Add Sentinel security incident note documenting the TypeScript module resolution path traversal vulnerability and its remediation.