### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal risk in manual path normalization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Path Traversal in Manual Path Component Normalization
+**Vulnerability:** Path traversal risk during manual path normalization (when `std::fs::canonicalize` fails). In `typescript.rs`, handling `Component::ParentDir` by only calling `components.pop()` allows excessive `../` to resolve up to the root, bypassing intended base path constraints.
+**Learning:** `std::path::Component::ParentDir` shouldn't blindly pop the last component. If the component stack is empty or its last element is also `ParentDir`, popping ignores the traversal intent.
+**Prevention:** Explicitly match against the last element of the component stack before handling `ParentDir`. If it's a `RootDir` or `Prefix`, ignore. If it's a `ParentDir` or `None`, push the `ParentDir`. Only pop when the last element is `Normal`.

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,18 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            let last = components.last().copied();
+                            match last {
+                                Some(std::path::Component::RootDir)
+                                | Some(std::path::Component::Prefix(_)) => {}
+                                Some(std::path::Component::ParentDir) | None => {
+                                    components.push(component)
+                                }
+                                Some(std::path::Component::Normal(_)) => {
+                                    components.pop();
+                                }
+                                Some(std::path::Component::CurDir) => unreachable!(),
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal risk during manual path normalization in `TypeScriptDependencyExtractor`. When `std::fs::canonicalize` fails, the manual fallback logic blindly pops components when encountering `../`. This ignores root directory limits and swallows `../` inside purely relative paths, allowing potential escapes outside the intended base path if the specifier is crafted.
🎯 Impact: An attacker could craft an import specifier with excessive `../` components to resolve arbitrary paths relative to the root if `canonicalize` falls back, potentially exposing or including unintended files.
🔧 Fix: Updated the `Component::ParentDir` handling in `typescript.rs` to accurately mirror Rust's standard path normalization logic. It now ignores `../` at the root and appropriately pushes `../` if the stack is empty or the last component is also a `../`.
✅ Verification: Ran `cargo test -p thread-flow --test extractor_typescript_tests` locally, which passed all test cases. Cleaned up all scratch files.

---
*PR created automatically by Jules for task [15445594305116898096](https://jules.google.com/task/15445594305116898096) started by @bashandbone*

## Summary by Sourcery

Fix TypeScript dependency extraction path normalization to prevent path traversal when canonicalization fails and document the vulnerability and its mitigation.

Bug Fixes:
- Correct manual handling of parent directory components during path normalization to respect root boundaries and avoid unintended directory escapes.

Documentation:
- Add a Sentinel security note documenting the path traversal vulnerability in manual path normalization and the lessons learned.