### PR TITLE
⚡ Bolt: [performance improvement] Optimize D1 query generation

### DIFF
--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/targets/d1.rs
+++ b/crates/flow/src/targets/d1.rs
@@ -300,40 +300,63 @@ impl D1ExportContext {
         key: &KeyValue,
         values: &FieldValues,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut columns = vec![];
-        let mut placeholders = vec![];
-        let mut params = vec![];
-        let mut update_clauses = vec![];
+        use std::fmt::Write;
 
+        // ⚡ Bolt Optimization: Use String::with_capacity and write! to avoid intermediate Vec allocations
+        // and string copying during query generation.
+        let mut sql = String::with_capacity(256);
+        let mut params = Vec::with_capacity(self.key_fields_schema.len() + values.fields.len());
+
+        write!(sql, "INSERT INTO {} (", self.table_name)
+            .map_err(|e| RecocoError::internal_msg(e.to_string()))?;
+
+        let mut first = true;
         // Extract key parts - KeyValue is a wrapper around Box<[KeyPart]>
-        for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
+        for (idx, key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                columns.push(self.key_fields_schema[idx].name.clone());
-                placeholders.push("?".to_string());
+                if !first {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&key_field.name);
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
 
         // Add value fields
         for (idx, value) in values.fields.iter().enumerate() {
             if let Some(value_field) = self.value_fields_schema.get(idx) {
-                columns.push(value_field.name.clone());
-                placeholders.push("?".to_string());
+                if !first {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&value_field.name);
                 params.push(value_to_json(value)?);
-                update_clauses.push(format!(
-                    "{} = excluded.{}",
-                    value_field.name, value_field.name
-                ));
+                first = false;
             }
         }
 
-        let sql = format!(
-            "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO UPDATE SET {}",
-            self.table_name,
-            columns.join(", "),
-            placeholders.join(", "),
-            update_clauses.join(", ")
-        );
+        sql.push_str(") VALUES (");
+
+        for i in 0..params.len() {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push('?');
+        }
+
+        sql.push_str(") ON CONFLICT DO UPDATE SET ");
+
+        first = true;
+        for (idx, _value) in values.fields.iter().enumerate() {
+            if let Some(value_field) = self.value_fields_schema.get(idx) {
+                if !first {
+                    sql.push_str(", ");
+                }
+                write!(sql, "{} = excluded.{}", value_field.name, value_field.name)
+                    .map_err(|e| RecocoError::internal_msg(e.to_string()))?;
+                first = false;
+            }
+        }
 
         Ok((sql, params))
     }
@@ -342,21 +365,27 @@ impl D1ExportContext {
         &self,
         key: &KeyValue,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut where_clauses = vec![];
-        let mut params = vec![];
+        use std::fmt::Write;
 
-        for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
+        // ⚡ Bolt Optimization: Avoid intermediate Vec allocations
+        let mut sql = String::with_capacity(128);
+        write!(sql, "DELETE FROM {} WHERE ", self.table_name)
+            .map_err(|e| RecocoError::internal_msg(e.to_string()))?;
+
+        let mut params = Vec::with_capacity(self.key_fields_schema.len());
+        let mut first = true;
+
+        for (idx, key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                where_clauses.push(format!("{} = ?", self.key_fields_schema[idx].name));
+                if !first {
+                    sql.push_str(" AND ");
+                }
+                write!(sql, "{} = ?", key_field.name)
+                    .map_err(|e| RecocoError::internal_msg(e.to_string()))?;
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
-
-        let sql = format!(
-            "DELETE FROM {} WHERE {}",
-            self.table_name,
-            where_clauses.join(" AND ")
-        );
 
         Ok((sql, params))
     }

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
💡 What: Replaced intermediate vector allocations (`columns`, `placeholders`, `update_clauses`, `where_clauses`) in D1 query builders (`build_upsert_stmt`, `build_delete_stmt`) with a pre-allocated `String` using `String::with_capacity` and `std::fmt::Write`.

🎯 Why: SQL query generation happens frequently during D1 target synchronization. The previous implementation used multiple `Vec<String>` allocations and `format!` / `join` operations per query, causing unnecessary memory allocation and string copying overhead.

📊 Impact: Significantly reduces heap allocations and string formatting overhead for every D1 upsert and delete statement generated, leading to faster execution and less GC/memory churn during export operations.

🔬 Measurement: Verified by running formatting, linting, and targeted D1 target tests (`cargo test -p thread-flow --test d1_target_tests --test d1_minimal_tests --test d1_cache_integration`), ensuring no regressions and that the generated SQL exactly matches the previous logic.

---
*PR created automatically by Jules for task [12786738793941327599](https://jules.google.com/task/12786738793941327599) started by @bashandbone*

## Summary by Sourcery

Optimize D1 SQL upsert and delete statement generation to reduce allocations and improve performance during target synchronization.

Enhancements:
- Replace intermediate vectors with preallocated SQL strings and direct writes in D1 upsert and delete builders to minimize memory allocations.
- Tidy up string handling and formatting in AST and rule engine modules for clearer, more consistent code.