### PR TITLE
🛡️ Sentinel: [improvement] Pre-canonicalize base path in FileSystemContext to avoid symlink escapes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Pre-canonicalize base path in FileSystemContext to avoid symlink escapes
+**Vulnerability:** The `FileSystemContext::new` accepted an uncanonicalized base path, which could potentially lead to symlink escapes during path validation.
+**Learning:** By canonicalizing the base path during construction, the check inside `secure_path` accurately determines if the target escapes the expected path, which wasn't fully guaranteed with an uncanonicalized base path.
+**Prevention:** Always construct secure contexts with canonicalized paths when implementing file path validation checks, especially to prevent symlink traversal.

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -142,10 +142,11 @@ pub struct FileSystemContext {
 }
 
 impl FileSystemContext {
-    pub fn new<P: AsRef<Path>>(base_path: P) -> Self {
-        Self {
-            base_path: base_path.as_ref().to_path_buf(),
-        }
+    pub fn new<P: AsRef<Path>>(base_path: P) -> ServiceResult<Self> {
+        let canonical_base = base_path.as_ref().canonicalize()?;
+        Ok(Self {
+            base_path: canonical_base,
+        })
     }
 
     /// Lexically validate path to prevent traversal attacks and symlink escapes
@@ -310,7 +311,7 @@ mod tests {
     #[test]
     fn test_file_system_context_security() {
         let temp = std::env::temp_dir();
-        let ctx = FileSystemContext::new(&temp);
+        let ctx = FileSystemContext::new(&temp).unwrap();
 
         // Valid paths
         assert!(ctx.secure_path("test.txt").is_ok());

--- a/crates/thread/tests/integration.rs
+++ b/crates/thread/tests/integration.rs
@@ -18,5 +18,5 @@ fn test_service_reexports_work() {
     use thread::services::FileSystemContext;
 
     // Just check if we can use the types
-    let _ctx = FileSystemContext::new(".");
+    let _ctx = FileSystemContext::new(".").unwrap();
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `FileSystemContext::new` previously accepted an uncanonicalized base path. When validating paths against a sandbox, an uncanonicalized base path can lead to symlink traversal bypasses if the base path itself contains symlinks that resolve unexpectedly compared to the target path.
🎯 **Impact:** Potential path traversal or symlink escapes during file system sandbox validation in the service layer, although practically limited by whether the base path is user-controlled.
🔧 **Fix:** Changed `FileSystemContext::new` to return a `ServiceResult<Self>` and explicitly `canonicalize()` the base path at creation time, guaranteeing an absolute, symlink-free sandbox root for all subsequent `secure_path` checks. Updated usage in tests to handle the `Result`.
✅ **Verification:** Verified by running the existing `test_file_system_context_security` suite and unit tests (`cargo test -p thread-services`), ensuring all security checks and standard usages still operate as intended.

---
*PR created automatically by Jules for task [17483386213109417647](https://jules.google.com/task/17483386213109417647) started by @bashandbone*

## Summary by Sourcery

Canonicalize the base path used by FileSystemContext at construction time to harden sandboxed path validation against symlink-based escapes.

Bug Fixes:
- Ensure FileSystemContext always uses a canonicalized, absolute base path to prevent potential symlink traversal escapes during secure_path checks.

Enhancements:
- Update FileSystemContext::new to return a ServiceResult and adjust call sites to handle potential construction failures.

Documentation:
- Add a Sentinel security note documenting the FileSystemContext base path canonicalization change and its rationale.