### PR TITLE
⚡ Bolt: [performance improvement] Optimize D1 target SQL statement building

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 ## 2026-04-08 - [Performance: Defer Allocation during Traversal]
 **Learning:** During DAG traversals, creating owned variants of identifiers (like `file.to_path_buf()`) *before* checking `visited` HashSets results in heap allocations (O(E)) for every edge instead of every visited node (O(V)). By moving the `&PathBuf` allocation strictly *after* all HashSet `contains` checks using the borrowed reference (`&Path`), we drastically reduce memory churn.
 **Action:** Always check `HashSet::contains` with a borrowed reference *before* creating the owned version required by `HashSet::insert`, especially in performance-critical graph traversal paths.
+
+## 2026-05-20 - [Performance: Direct String Formatting for SQL Queries]
+**Learning:** In hot paths building dynamic strings (like SQL query generators `build_upsert_stmt`), repeatedly using `format!` and creating intermediate vectors for `.join()` results in high memory churn and excessive heap allocations per query.
+**Action:** Use `String::with_capacity` paired with the `write!` macro (`std::fmt::Write`) and exact-capacity `Vec` pre-allocations to build dynamic strings directly into a single buffer, drastically reducing intermediate allocations.

--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/targets/d1.rs
+++ b/crates/flow/src/targets/d1.rs
@@ -300,40 +300,63 @@ impl D1ExportContext {
         key: &KeyValue,
         values: &FieldValues,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut columns = vec![];
-        let mut placeholders = vec![];
-        let mut params = vec![];
-        let mut update_clauses = vec![];
+        let mut params =
+            Vec::with_capacity(self.key_fields_schema.len() + self.value_fields_schema.len());
+        let mut sql = String::with_capacity(
+            128 + self.key_fields_schema.len() * 16 + self.value_fields_schema.len() * 32,
+        );
+
+        use std::fmt::Write;
+        let _ = write!(sql, "INSERT INTO {} (", self.table_name);
+
+        let mut first = true;
 
         // Extract key parts - KeyValue is a wrapper around Box<[KeyPart]>
-        for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
+        for (idx, key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                columns.push(self.key_fields_schema[idx].name.clone());
-                placeholders.push("?".to_string());
+                if !first {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&key_field.name);
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
 
         // Add value fields
         for (idx, value) in values.fields.iter().enumerate() {
             if let Some(value_field) = self.value_fields_schema.get(idx) {
-                columns.push(value_field.name.clone());
-                placeholders.push("?".to_string());
+                if !first {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&value_field.name);
                 params.push(value_to_json(value)?);
-                update_clauses.push(format!(
-                    "{} = excluded.{}",
-                    value_field.name, value_field.name
-                ));
+                first = false;
             }
         }
 
-        let sql = format!(
-            "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO UPDATE SET {}",
-            self.table_name,
-            columns.join(", "),
-            placeholders.join(", "),
-            update_clauses.join(", ")
-        );
+        sql.push_str(") VALUES (");
+
+        for i in 0..params.len() {
+            if i > 0 {
+                sql.push_str(", ?");
+            } else {
+                sql.push('?');
+            }
+        }
+
+        sql.push_str(") ON CONFLICT DO UPDATE SET ");
+
+        let mut first_update = true;
+        for (idx, _value) in values.fields.iter().enumerate() {
+            if let Some(value_field) = self.value_fields_schema.get(idx) {
+                if !first_update {
+                    sql.push_str(", ");
+                }
+                let _ = write!(sql, "{} = excluded.{}", value_field.name, value_field.name);
+                first_update = false;
+            }
+        }
 
         Ok((sql, params))
     }
@@ -342,21 +365,23 @@ impl D1ExportContext {
         &self,
         key: &KeyValue,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut where_clauses = vec![];
-        let mut params = vec![];
+        let mut params = Vec::with_capacity(self.key_fields_schema.len());
+        let mut sql = String::with_capacity(64 + self.key_fields_schema.len() * 16);
 
-        for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
+        use std::fmt::Write;
+        let _ = write!(sql, "DELETE FROM {} WHERE ", self.table_name);
+
+        let mut first = true;
+        for (idx, key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                where_clauses.push(format!("{} = ?", self.key_fields_schema[idx].name));
+                if !first {
+                    sql.push_str(" AND ");
+                }
+                let _ = write!(sql, "{} = ?", key_field.name);
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
-
-        let sql = format!(
-            "DELETE FROM {} WHERE {}",
-            self.table_name,
-            where_clauses.join(" AND ")
-        );
 
         Ok((sql, params))
     }

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
💡 What
Refactored `build_upsert_stmt` and `build_delete_stmt` in `crates/flow/src/targets/d1.rs` to construct dynamic SQL queries directly into pre-allocated `String` buffers using `std::fmt::Write`. This replaces the previous pattern of collecting query parts into intermediate vectors (`vec![]`) and using `format!` with `.join()`. Query parameter vectors are also now pre-allocated with exact capacities.

🎯 Why
The previous implementation performed multiple heap allocations per query to create intermediate strings and vectors, causing unnecessary memory churn on a hot path during data export to Cloudflare D1 targets.

📊 Impact
Significantly reduces heap allocations and string copying overhead per generated SQL query, which improves memory efficiency and query generation throughput during bulk data exports.

🔬 Measurement
Verify the optimizations by running `cargo test -p thread-flow --test d1_target_tests --test d1_minimal_tests` to ensure that identical, correct SQL queries are still being generated under the new, faster implementation.

---
*PR created automatically by Jules for task [10239718748718497456](https://jules.google.com/task/10239718748718497456) started by @bashandbone*

## Summary by Sourcery

Optimize SQL statement construction for D1 exports and perform minor API and formatting cleanups across supporting crates.

Enhancements:
- Build D1 upsert and delete SQL statements directly into pre-allocated string buffers while pre-sizing parameter vectors to reduce allocations on a hot path.
- Simplify lifetime usage in variable checking helpers by removing unnecessary explicit lifetimes from function signatures.
- Tidy up string and assertion formatting for improved readability in AST and rule engine modules.

Documentation:
- Add a Bolt engineering note documenting the performance pattern of direct string formatting for dynamic SQL query construction.