### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-20 - Lexical Path Normalization Traversal Vulnerability
+**Vulnerability:** In `crates/flow/src/incremental/extractors/typescript.rs`, manual path normalization handled `..` components by blindly calling `components.pop()`.
+**Learning:** If `components` was empty or contained boundary components like `/` (`RootDir`), popping did nothing, effectively deleting `..` directories and breaking relative navigation. Alternatively, `components.pop()` would happily strip root indicators, allowing path ascensions to escape intended root scopes.
+**Prevention:** When manually normalizing paths using `std::path::Component`, explicitly block `ParentDir` from popping `RootDir` or `Prefix`. If the components stack is empty or its top is already `ParentDir`, push the new `ParentDir` to preserve valid ascensions (e.g., `../../file`).

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,17 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            let last = components.last().copied();
+                            match last {
+                                None | Some(std::path::Component::ParentDir) => {
+                                    components.push(component);
+                                }
+                                Some(std::path::Component::RootDir)
+                                | Some(std::path::Component::Prefix(_)) => {}
+                                _ => {
+                                    components.pop();
+                                }
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: In `crates/flow/src/incremental/extractors/typescript.rs`, manual path normalization handled `..` components by blindly calling `components.pop()`. This effectively meant `../` components could silently disappear or strip root path components.
🎯 Impact: This flaw breaks relative navigation and creates a path traversal vulnerability where ascensions (`..`) could escape intended root scopes or incorrectly simplify relative paths, leading to incorrect file access or bypassed path constraints.
🔧 Fix: Updated the path canonicalization to properly implement lexical resolution. It now pushes `..` if the path is empty or already ends in `..` (preserving necessary ascensions), ignores `..` if the path is at a root or prefix boundary (preventing traversal above root), and safely pops otherwise.
✅ Verification: Ran unit tests for the TypeScript extractor (`cargo test -p thread-flow --test extractor_typescript_tests`) which all pass successfully.

---
*PR created automatically by Jules for task [10142149368411894985](https://jules.google.com/task/10142149368411894985) started by @bashandbone*

## Summary by Sourcery

Fix unsafe path normalization in the TypeScript dependency extractor to prevent path traversal and document the vulnerability and its mitigation.

Bug Fixes:
- Harden handling of parent directory components in the TypeScript dependency extractor to prevent escaping root or losing necessary ascensions during path normalization.

Documentation:
- Add Sentinel documentation entry describing the lexical path normalization vulnerability, its impact, and the correct mitigation approach.