### PR TITLE
⚡ Bolt: [performance improvement] Defer PathBuf allocations in Tarjan's SCC DFS

### DIFF
--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -358,19 +358,19 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();


### PR DESCRIPTION
💡 What: Replaced `v.to_path_buf()` with `v` (borrowed `&Path`) in `state.lowlinks.get_mut` and `state.indices.get` calls during the recursive `tarjan_dfs` graph traversal algorithm.

🎯 Why: In recursive DFS traversal functions over a dependency graph, repeatedly calling `.to_path_buf()` right before querying a map creates a substantial number of temporary heap allocations (one for every visited edge in SCC check). Using the borrowed reference eliminates O(E) unnecessary heap memory allocations inside `RapidMap::get_mut()` lookups.

📊 Impact: Reduces memory overhead and time spent allocating strings/paths on the heap significantly when computing invalidations for very large and deeply nested dependency graphs.

🔬 Measurement: Run `cargo test -p thread-flow --test invalidation_tests` to verify graph traversals still succeed, ensuring there are no regressions. Measure runtime impact with `cargo test --test test_performance_large_graph` or equivalent backend benchmarks.

---
*PR created automatically by Jules for task [7578039882070192528](https://jules.google.com/task/7578039882070192528) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Use borrowed Path references instead of allocating new PathBufs for lowlink and index lookups in the Tarjan SCC invalidation logic.