### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in manual path normalization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Path Traversal in Manual Path Resolution]
+**Vulnerability:** In `resolve_module_path`, manual path normalization for unresolved paths incorrectly popped `std::path::Component::ParentDir` from the components list regardless of the previous component. This could pop `RootDir` or `Prefix` components, leading to potential path traversal vulnerabilities or generating entirely wrong absolute paths when given multiple `..` segments.
+**Learning:** `std::path::Component` does not inherently block you from popping structural elements like `RootDir`. When manually normalizing paths by collecting components, you must handle `..` explicitly by checking the last element before popping.
+**Prevention:** Always verify the type of the last component before popping it for a `ParentDir`. Explicitly ignore `ParentDir` if the last component is `RootDir` or `Prefix`, and push it if the list is empty or the last component is also `ParentDir`.

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,15 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            if let Some(last) = components.last() {
+                                match last {
+                                    std::path::Component::RootDir | std::path::Component::Prefix(_) => {}
+                                    std::path::Component::ParentDir => components.push(component),
+                                    _ => { components.pop(); }
+                                }
+                            } else {
+                                components.push(component);
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The manual path normalization for unresolved paths in `crates/flow/src/incremental/extractors/typescript.rs` incorrectly popped `std::path::Component::ParentDir` from the components list regardless of the previous component. This could pop `RootDir` or `Prefix` components, leading to path traversal vulnerabilities and incorrect path resolution for multiple `..` segments.
🎯 Impact: An attacker could potentially use maliciously crafted import paths with multiple `..` segments to traverse out of the intended directory and access sensitive files, especially when manual canonicalization is triggered for non-existent or unresolvable paths.
🔧 Fix: Updated the `Component::ParentDir` match arm to safely handle popping components. It now ignores `ParentDir` if the last component is `RootDir` or `Prefix`, pushes `ParentDir` if the components list is empty or the last component is also a `ParentDir`, and otherwise safely pops the last directory.
✅ Verification: Ran `cargo test -p thread-flow --test extractor_typescript_tests` to verify no functionality is broken and path resolutions succeed correctly.

---
*PR created automatically by Jules for task [10888592995321208738](https://jules.google.com/task/10888592995321208738) started by @bashandbone*

## Summary by Sourcery

Harden manual path normalization in the TypeScript dependency extractor to prevent unsafe handling of parent directory components in module path resolution.

Bug Fixes:
- Prevent path traversal and incorrect absolute path resolution by safely handling `ParentDir` components when normalizing unresolved module paths.

Documentation:
- Add a Sentinel incident note documenting the path traversal vulnerability, its cause, and prevention guidelines for manual path normalization.