### PR TITLE
⚡ Bolt: [performance improvement] Reduce heap allocations in Tarjan's SCC algorithm

### DIFF
--- a/crates/flow/src/incremental/invalidation.rs
+++ b/crates/flow/src/incremental/invalidation.rs
@@ -342,11 +342,12 @@ impl InvalidationDetector {
     fn tarjan_dfs(&self, v: &Path, state: &mut TarjanState, sccs: &mut Vec<Vec<PathBuf>>) {
         // Initialize node
         let index = state.index_counter;
-        state.indices.insert(v.to_path_buf(), index);
-        state.lowlinks.insert(v.to_path_buf(), index);
+        let v_buf = v.to_path_buf();
+        state.indices.insert(v_buf.clone(), index);
+        state.lowlinks.insert(v_buf.clone(), index);
         state.index_counter += 1;
-        state.stack.push(v.to_path_buf());
-        state.on_stack.insert(v.to_path_buf());
+        state.stack.push(v_buf.clone());
+        state.on_stack.insert(v_buf);
 
         // Visit all successors (dependencies)
         let dependencies = self.graph.get_dependencies(v);
@@ -358,19 +359,19 @@ impl InvalidationDetector {
 
                 // Update lowlink
                 let w_lowlink = *state.lowlinks.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_lowlink);
             } else if state.on_stack.contains(dep) {
                 // Successor is on stack (part of current SCC)
                 let w_index = *state.indices.get(dep).unwrap();
-                let v_lowlink = state.lowlinks.get_mut(&v.to_path_buf()).unwrap();
+                let v_lowlink = state.lowlinks.get_mut(v).unwrap();
                 *v_lowlink = (*v_lowlink).min(w_index);
             }
         }
 
         // If v is a root node, pop the stack to create an SCC
-        let v_index = *state.indices.get(&v.to_path_buf()).unwrap();
-        let v_lowlink = *state.lowlinks.get(&v.to_path_buf()).unwrap();
+        let v_index = *state.indices.get(v).unwrap();
+        let v_lowlink = *state.lowlinks.get(v).unwrap();
 
         if v_lowlink == v_index {
             let mut scc = Vec::new();


### PR DESCRIPTION
💡 What: Extracted multiple `v.to_path_buf()` calls into a single allocated `PathBuf` and leveraged borrowed lookups (`.get(v)`) where possible in `tarjan_dfs`.
🎯 Why: To remove redundant O(E) heap allocations in performance-critical dependency graph traversals.
📊 Impact: Substantially reduces memory allocation churn, preventing degraded performance on very large graphs.
🔬 Measurement: Run the `thread-flow` benchmarks (`cargo bench -p thread-flow`) to observe graph traversal speedup.

---
*PR created automatically by Jules for task [13477554990645438749](https://jules.google.com/task/13477554990645438749) started by @bashandbone*

## Summary by Sourcery

Enhancements:
- Reuse a single PathBuf per node and switch to borrowed map lookups in tarjan_dfs to lower heap allocation overhead during graph traversal.