### PR TITLE
⚡ Bolt: [performance improvement] Optimize D1 SQL string allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,6 @@
 ## 2026-04-08 - [Performance: Defer Allocation during Traversal]
 **Learning:** During DAG traversals, creating owned variants of identifiers (like `file.to_path_buf()`) *before* checking `visited` HashSets results in heap allocations (O(E)) for every edge instead of every visited node (O(V)). By moving the `&PathBuf` allocation strictly *after* all HashSet `contains` checks using the borrowed reference (`&Path`), we drastically reduce memory churn.
 **Action:** Always check `HashSet::contains` with a borrowed reference *before* creating the owned version required by `HashSet::insert`, especially in performance-critical graph traversal paths.
+## 2026-04-10 - [Performance: Direct SQL String Formatting]
+**Learning:** In D1 target components (`build_upsert_stmt`), dynamically generating SQL using intermediate `Vec` allocations combined with `.join()` operations causes unnecessary heap allocations and copying. Constructing the raw SQL query directly via `std::fmt::Write` to a single pre-allocated `String` significantly reduces memory overhead.
+**Action:** For dynamic SQL generation on high-frequency paths, use `String::with_capacity` and `write!` instead of intermediate arrays and `.join()`.

--- a/crates/ast-engine/src/tree_sitter/mod.rs
+++ b/crates/ast-engine/src/tree_sitter/mod.rs
@@ -553,9 +553,8 @@ impl ContentExt for String {
         let mut bytes = std::mem::take(self).into_bytes();
         let original_len = bytes.len();
         bytes.splice(safe_start..safe_end, full_inserted);
-        *self = Self::from_utf8(bytes).unwrap_or_else(|e| {
-            Self::from_utf8_lossy(&e.into_bytes()).into_owned()
-        });
+        *self = Self::from_utf8(bytes)
+            .unwrap_or_else(|e| Self::from_utf8_lossy(&e.into_bytes()).into_owned());
 
         // We calculate new_end_byte using the difference in the new overall string length
         // to correctly align the end offset, taking any potential replacement bytes from
@@ -791,7 +790,10 @@ mod test {
 
         let tree2 = parse_lang(|p| p.parse(&src, Some(&tree)), &Tsx.get_ts_language())?;
         let fresh_tree = parse(&src)?;
-        assert_eq!(tree2.root_node().to_sexp(), fresh_tree.root_node().to_sexp());
+        assert_eq!(
+            tree2.root_node().to_sexp(),
+            fresh_tree.root_node().to_sexp()
+        );
         Ok(())
     }
 }

--- a/crates/flow/src/targets/d1.rs
+++ b/crates/flow/src/targets/d1.rs
@@ -300,40 +300,51 @@ impl D1ExportContext {
         key: &KeyValue,
         values: &FieldValues,
     ) -> Result<(String, Vec<serde_json::Value>), RecocoError> {
-        let mut columns = vec![];
-        let mut placeholders = vec![];
-        let mut params = vec![];
-        let mut update_clauses = vec![];
+        use std::fmt::Write;
+        let mut params = Vec::with_capacity(self.key_fields_schema.len() + values.fields.len());
+        // ⚡ Bolt: Direct SQL construction to avoid intermediate String and Vec allocations
+        let mut sql = String::with_capacity(256);
+        let _ = write!(sql, "INSERT INTO {} (", self.table_name);
 
-        // Extract key parts - KeyValue is a wrapper around Box<[KeyPart]>
+        let mut first = true;
+        let mut update_clauses = String::with_capacity(128);
+        let mut first_upd = true;
+
         for (idx, _key_field) in self.key_fields_schema.iter().enumerate() {
             if let Some(key_part) = key.0.get(idx) {
-                columns.push(self.key_fields_schema[idx].name.clone());
-                placeholders.push("?".to_string());
+                if !first {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&self.key_fields_schema[idx].name);
                 params.push(key_part_to_json(key_part)?);
+                first = false;
             }
         }
-
-        // Add value fields
         for (idx, value) in values.fields.iter().enumerate() {
-            if let Some(value_field) = self.value_fields_schema.get(idx) {
-                columns.push(value_field.name.clone());
-                placeholders.push("?".to_string());
+            if let Some(field) = self.value_fields_schema.get(idx) {
+                if !first {
+                    sql.push_str(", ");
+                }
+                sql.push_str(&field.name);
                 params.push(value_to_json(value)?);
-                update_clauses.push(format!(
-                    "{} = excluded.{}",
-                    value_field.name, value_field.name
-                ));
+                first = false;
+
+                if !first_upd {
+                    update_clauses.push_str(", ");
+                }
+                let _ = write!(update_clauses, "{0} = excluded.{0}", field.name);
+                first_upd = false;
             }
         }
 
-        let sql = format!(
-            "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO UPDATE SET {}",
-            self.table_name,
-            columns.join(", "),
-            placeholders.join(", "),
-            update_clauses.join(", ")
-        );
+        sql.push_str(") VALUES (");
+        for i in 0..params.len() {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push('?');
+        }
+        let _ = write!(sql, ") ON CONFLICT DO UPDATE SET {}", update_clauses);
 
         Ok((sql, params))
     }

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);

--- a/crates/rule-engine/src/rule/mod.rs
+++ b/crates/rule-engine/src/rule/mod.rs
@@ -246,7 +246,11 @@ impl Rule {
 
     pub fn defined_vars(&self) -> RapidSet<String> {
         match self {
-            Rule::Pattern(p) => p.defined_vars().into_iter().map(|s| s.to_string()).collect(),
+            Rule::Pattern(p) => p
+                .defined_vars()
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
             Rule::Kind(_) => RapidSet::default(),
             Rule::Regex(_) => RapidSet::default(),
             Rule::NthChild(n) => n.defined_vars(),

--- a/crates/rule-engine/src/rule/referent_rule.rs
+++ b/crates/rule-engine/src/rule/referent_rule.rs
@@ -27,10 +27,7 @@ impl<R> Clone for Registration<R> {
 
 impl<R> Registration<R> {
     fn read(&self) -> Arc<RapidMap<String, R>> {
-        self.0
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
     pub(crate) fn contains_key(&self, key: &str) -> bool {
         self.read().contains_key(key)


### PR DESCRIPTION
💡 What:
Replaced dynamic `String` format and `.join(", ")` loop logic with `String::with_capacity` and `std::fmt::Write` to construct the SQL query directly into a pre-allocated String buffer inside `crates/flow/src/targets/d1.rs` (`build_upsert_stmt`).

🎯 Why:
The original approach created multiple intermediate `Vec` collections and `String` allocations (via `format!`) for generating parameter lists and update clauses. By constructing the SQL string sequentially, we avoid these unnecessary intermediate heap allocations and string copy operations, directly reducing O(n) memory churn for every upsert call on high-throughput database paths.

📊 Impact:
Reduces heap allocation per query building substantially. This eliminates intermediate `Vec<String>` instances when generating lists of keys and update values.

🔬 Measurement:
Run `cargo bench -p thread-flow --bench d1_profiling --features caching` to measure latency, though running it requires `caching` feature. Tests were verified with `cargo test -p thread-flow --test d1_target_tests --test d1_minimal_tests --test d1_cache_integration`.

---
*PR created automatically by Jules for task [16231611141592875904](https://jules.google.com/task/16231611141592875904) started by @bashandbone*

## Summary by Sourcery

Optimize D1 upsert SQL construction to reduce allocations and perform minor API and formatting cleanups across AST and rule engine modules.

Enhancements:
- Build D1 upsert INSERT/ON CONFLICT SQL directly into a pre-allocated String buffer to avoid intermediate String and Vec allocations.
- Simplify rule-engine helper function signatures by removing unnecessary lifetimes and tightening references for constraints and transforms.
- Tidy AST engine and rule-engine code formatting and error handling for clearer, more consistent style.

Documentation:
- Extend Bolt performance notes with guidance on direct SQL string formatting for high-frequency paths.