### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in typescript extractor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Path Traversal in TypeScript Module Resolution
+**Vulnerability:** The manual path normalization logic for unresolved TypeScript modules blindly called `components.pop()` when encountering `..` (ParentDir), which would swallow components when the list was empty, allowing path traversal outside of intended boundaries.
+**Learning:** Rust's `Path::components()` does not automatically normalize `.` and `..` away. Manual normalization must explicitly track when components is empty or ends in `..` and push `ParentDir` in those cases instead of ignoring/popping it, otherwise `../../../file` resolves as `file`.
+**Prevention:** Whenever manually resolving paths with `std::path::Component`, block `ParentDir` from popping `RootDir` or `Prefix`, and explicitly push `ParentDir` if the current component list is empty or its last element is `ParentDir`.

--- a/crates/flow/src/incremental/extractors/typescript.rs
+++ b/crates/flow/src/incremental/extractors/typescript.rs
@@ -808,7 +808,19 @@ impl TypeScriptDependencyExtractor {
                 for component in resolved.components() {
                     match component {
                         std::path::Component::ParentDir => {
-                            components.pop();
+                            let last = components.last().copied();
+                            match last {
+                                Some(std::path::Component::RootDir)
+                                | Some(std::path::Component::Prefix(_)) => {
+                                    // Ignore: cannot pop root or prefix
+                                }
+                                Some(std::path::Component::ParentDir) | None => {
+                                    components.push(component);
+                                }
+                                _ => {
+                                    components.pop();
+                                }
+                            }
                         }
                         std::path::Component::CurDir => {}
                         _ => components.push(component),

--- a/crates/rule-engine/src/check_var.rs
+++ b/crates/rule-engine/src/check_var.rs
@@ -104,9 +104,9 @@ fn get_vars_from_rules<'r>(rule: &'r Rule, utils: &'r RuleRegistration) -> Rapid
     vars
 }
 
-fn check_var_in_constraints<'r>(
+fn check_var_in_constraints(
     mut vars: RapidSet<String>,
-    constraints: &'r RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
+    constraints: &RapidMap<thread_ast_engine::meta_var::MetaVariableID, Rule>,
 ) -> RResult<RapidSet<String>> {
     for rule in constraints.values() {
         for var in rule.defined_vars() {
@@ -125,9 +125,9 @@ fn check_var_in_constraints<'r>(
     Ok(vars)
 }
 
-fn check_var_in_transform<'r>(
+fn check_var_in_transform(
     mut vars: RapidSet<String>,
-    transform: &'r Option<Transform>,
+    transform: &Option<Transform>,
 ) -> RResult<RapidSet<String>> {
     let Some(transform) = transform else {
         return Ok(vars);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `TypeScriptDependencyExtractor` manually normalized paths and blindly popped the `components` vector when encountering `..` (`std::path::Component::ParentDir`). If the vector was empty (or navigating backwards multiple levels), it swallowed the `..`, which meant traversing `../../../sensitive` would simply resolve to `sensitive`, opening up the risk for path traversal vulnerabilities in dependency extraction.
🎯 Impact: An attacker controlling imports in a TypeScript file could force the extractor to resolve and process files outside of the intended source tree, potentially extracting contents or crashing the system depending on how the parsed results are handled.
🔧 Fix: Updated the normalization logic to securely inspect the last element in the components vector. It now correctly retains `..` if the list is empty or the last element is also `..`, prevents popping `RootDir` or `Prefix`, and only pops if the last component was a normal path directory. Also cleaned up some unused lifetimes in `crates/rule-engine/src/check_var.rs` caught by clippy.
✅ Verification: Ran unit tests for the TypeScript extractor (`cargo test -p thread-flow --test extractor_typescript_tests`) to ensure correct resolution behaviour and ensure no regressions were introduced. Also successfully ran `cargo clippy --workspace -- -D warnings`.

---
*PR created automatically by Jules for task [12822901857360876647](https://jules.google.com/task/12822901857360876647) started by @bashandbone*

## Summary by Sourcery

Fix insecure path normalization in the TypeScript dependency extractor to prevent path traversal and perform minor cleanup in the rule engine.

Bug Fixes:
- Ensure TypeScript module resolution correctly handles `..` components without allowing traversal outside the intended root or prefix.

Enhancements:
- Remove unnecessary lifetimes from rule engine variable checking helpers for cleaner type signatures.

Chores:
- Add a Sentinel incident note documenting the path traversal vulnerability, its root cause, and prevention guidance.